### PR TITLE
Update for nuxt@2.14 and make the regex handle ports

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -30,37 +30,16 @@ module.exports = function Extract(moduleOptions) {
     return await process(page)
   })
 
-  this.nuxt.hook('export:routeCreated', ({ route }) => {
+  this.nuxt.hook('generate:routeCreated', async ({ route }) => {
     const routePath = join(this.options.generate.dir, this.options.generate.staticAssets.versionBase, route)
     const payloadPath = join(routePath, 'payload.js')
+    return await rewritePayload(payloadPath)
+  })
 
-    // Parse payload.js to get encoded URIs
-    const test = new RegExp(
-      '(http(s?):)([\\\\u002F|.|\\w|\\s|-]|%|~|\\\\u002F)*.(?:' + options.extensions.join('|') + '){1}[^"]*',
-      'g'
-    )
-
-    const urls = []
-
-    fs.readFile(payloadPath, 'utf8', async (err, data) => {
-      if (err) return consola.error(err)
-      const matches = data.matchAll(test)
-
-      for (const match of matches) {
-        const baseUrl = new URL(moduleOptions.baseUrl)
-        const url = new URL(decodeURIComponent(JSON.parse('"' + removeTrailingBackslash(match[0]) + '"')))
-        if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
-          urls.push(url)
-        }
-      }
-      if (!urls.length) return
-
-      await replacePayloadImageLinks(data, urls).then((payload) => {
-        fs.writeFile(payloadPath, payload, 'utf8', (err) => {
-          if (err) return consola.error(err)
-        })
-      })
-    })
+  this.nuxt.hook('export:routeCreated', async ({ route }) => {
+    const routePath = join(this.options.generate.dir, this.options.generate.staticAssets.versionBase, route)
+    const payloadPath = join(routePath, 'payload.js')
+    return await rewritePayload(payloadPath)
   })
 
   async function process(page) {
@@ -97,6 +76,36 @@ module.exports = function Extract(moduleOptions) {
 
   function encodeSlashes(str) {
     return str.replace(/\//g, '\\u002F')
+  }
+
+  function rewritePayload(payloadPath) {
+    // Parse payload.js to get encoded URIs
+    const test = new RegExp(
+      '(http(s?):)([\\\\u002F|.|\\w|\\s|-]|%|~|\\\\u002F)*.(?:' + options.extensions.join('|') + '){1}[^"]*',
+      'g'
+    )
+
+    const urls = []
+
+    fs.readFile(payloadPath, 'utf8', async (err, data) => {
+      if (err) return consola.error(err)
+      const matches = data.matchAll(test)
+
+      for (const match of matches) {
+        const baseUrl = new URL(moduleOptions.baseUrl)
+        const url = new URL(decodeURIComponent(JSON.parse('"' + removeTrailingBackslash(match[0]) + '"')))
+        if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
+          urls.push(url)
+        }
+      }
+      if (!urls.length) return
+
+      await replacePayloadImageLinks(data, urls).then((payload) => {
+        fs.writeFile(payloadPath, payload, 'utf8', (err) => {
+          if (err) return consola.error(err)
+        })
+      })
+    })
   }
 
   function encodeChars(str) {

--- a/lib/module.js
+++ b/lib/module.js
@@ -44,7 +44,7 @@ module.exports = function Extract(moduleOptions) {
 
   async function process(page) {
     const urls = []
-    const test = new RegExp('(http(s?):)([/|.|\\w|\\s|-]|%|~)*.(?:' + options.extensions.join('|') + '){1}[^"]*', 'g')
+    const test = new RegExp('(http(s?):)([/|.|\\w|\\s|-]|%|:|~)*.(?:' + options.extensions.join('|') + '){1}[^"]*', 'g')
     const matches = page.html.matchAll(test)
     for (const match of matches) {
       const baseUrl = new URL(moduleOptions.baseUrl)
@@ -81,7 +81,7 @@ module.exports = function Extract(moduleOptions) {
   function rewritePayload(payloadPath) {
     // Parse payload.js to get encoded URIs
     const test = new RegExp(
-      '(http(s?):)([\\\\u002F|.|\\w|\\s|-]|%|~|\\\\u002F)*.(?:' + options.extensions.join('|') + '){1}[^"]*',
+      '(http(s?):)([\\\\u002F|.|\\w|\\s|-]|%|:|~|\\\\u002F)*.(?:' + options.extensions.join('|') + '){1}[^"]*',
       'g'
     )
 


### PR DESCRIPTION
Thanks for this library! I ran into a few small issues while using it to pull from a local instance of Ghost CMS. 

First is that the 'export:*' hooks have been deprecated in nuxt@2.14. Looks like "export:routeCreated" no longer works, and "generate:routeCreated" should be used instead. I left the deprecated hooks alone so that this package would remain functional on older nuxt versions, though users of >=2.14 will see warnings due to this.

Second is that the regex was failing to capture domains with a port due to the colon. (such as http://localhost:1234). So I updated your regex in both locations.
