### PR TITLE
Add support for srcset (responsive images)

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -34,12 +34,21 @@ module.exports = function Extract(moduleOptions) {
     const test = new RegExp('(http(s?):)([/|.|\\w|\\s|-]|%|:|~)*.(?:' + options.extensions.join('|') + '){1}[^"]*', 'g')
     const matches = page.html.matchAll(test)
     for (const match of matches) {
-      const baseUrl = new URL(moduleOptions.baseUrl)
-      const url = new URL(match[0])
-      if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
-        urls.push(url)
-      }
-    }
+			const baseUrl = new URL(moduleOptions.baseUrl)
+			const responsiveImagesRegex = /[,\s]+[\d.]+[xwh]\s?/gm;
+			const responsiveImageMatches = match[0].match(responsiveImagesRegex)
+			let matchURLStrings = [match[0]]
+			if ( responsiveImageMatches && responsiveImageMatches.length ) {
+				matchURLStrings = match[0].split(responsiveImagesRegex).filter(item => item.length)
+			}
+			const matchURLs = matchURLStrings.map(matchStr => new URL(matchStr));
+
+			matchURLs.forEach(url => {
+				if (!urls.find((u) => u.href === url.href)) {
+					urls.push(url)
+				}
+			})
+		}
     if (!urls.length) return
     consola.info(`${page.route}: nuxt-image-extractor is replacing ${urls.length} images with local copies`)
     return await replaceRemoteImages(page.html, urls).then((html) => (page.html = html))

--- a/lib/module.js
+++ b/lib/module.js
@@ -35,7 +35,7 @@ module.exports = function Extract(moduleOptions) {
     const matches = page.html.matchAll(test)
     for (const match of matches) {
 			const baseUrl = new URL(moduleOptions.baseUrl)
-			const responsiveImagesRegex = /[,\s]+[\d.]+[xwh]\s?/gm;
+			const responsiveImagesRegex = /,?\s{1}[\d.]+[xwh]\s?,?\s?/gm;
 			const responsiveImageMatches = match[0].match(responsiveImagesRegex)
 			let matchURLStrings = [match[0]]
 			if ( responsiveImageMatches && responsiveImageMatches.length ) {


### PR DESCRIPTION
Hi there,

Thank you for creating this module. It is very useful and I'm using it in one of my projects.

I noticed that using `srcset` attribute for responsive images would result in the wrong URLs being requested.

This patch adds support for the `srcset` attribute.

The changed code does the following:
If an URL match contains in fact two separate URLs, separated by an [responsive image size indicator](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images#resolution_switching_same_size_different_resolutions) (like `2.3x` or `200w`), it splits the match into two separate URLs to download and process instead of one.

As an example, given the following markup:

	<img src="images/600/02.jpg" srcset="images/1200/02.jpg 2x images/600/02.jpg 1x" />
	<img src="images/600/02.jpg" srcset="images/1200/02.jpg 1200w images/600/02.jpg 600w" />

it currently generates the following image URLs to download and process:

	[
		'images/1200/02.jpg%202x%20images/600/02.jpg',
		'images/1200/02.jpg%201200w%20images/600/02.jpg'
	]

The changed code generates the following URLs:

	[
		'images/1200/02.jpg',
		'images/600/02.jpg'
	]

Please let me know if you have any questions or want me to clarify anything.

Thanks again for creating this module!
