### PR TITLE
Fix baseUrl and erroneous downloads

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -152,6 +152,10 @@ module.exports = function Extract(moduleOptions) {
 
 async function saveRemoteImage(url, path) {
   const res = await fetch(url)
+  if(!res.ok) {
+    consola.error(`Failed to fetch: ${url} - Status: ${res.status}`)
+    process.exit(1)
+  }
   const fileStream = fs.createWriteStream(path)
   return await new Promise((resolve, reject) => {
     res.body.pipe(fileStream)

--- a/lib/module.js
+++ b/lib/module.js
@@ -44,7 +44,7 @@ module.exports = function Extract(moduleOptions) {
 			const matchURLs = matchURLStrings.map(matchStr => new URL(matchStr));
 
 			matchURLs.forEach(url => {
-				if (!urls.find((u) => u.href === url.href)) {
+				if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
 					urls.push(url)
 				}
 			})


### PR DESCRIPTION
This PR reimplements the missing hostname check which was removed in PR #12 

It also checks the status code for a download, as the functionality before it either silently failed, or hung infinitely (depending on the error type). I have considered this a fatal exception (`process.exit(1)`) as that will nicely fail build pipelines in the event assets are missing.