### PR TITLE
Refactor for payload image fetching

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -10,51 +10,61 @@ const defaults = {
   // TODO: add option to allow keeping the original folder structure
 }
 
-module.exports = function Extract(moduleOptions) {
+module.exports = function Extract (moduleOptions) {
   const options = { ...defaults, ...moduleOptions }
   const baseDir = join(this.options.generate.dir, options.path)
   const routerBase = this.options.router.base !== '/' ? this.options.router.base : ''
+  const baseUrl = new URL(moduleOptions.baseUrl)
 
   this.nuxt.hook('generate:distCopied', () => {
-    if (!fs.existsSync(baseDir)) fs.mkdirSync(baseDir)
+    if (!fs.existsSync(baseDir)) { fs.mkdirSync(baseDir) }
   })
 
   this.nuxt.hook('generate:page', async (page) => {
-    return await process(page)
+    return await processPage(page)
   })
 
   this.nuxt.hook('generate:routeCreated', async ({ route }) => {
     const routePath = join(this.options.generate.dir, this.options.generate.staticAssets.versionBase, route)
     const payloadPath = join(routePath, 'payload.js')
-    return await rewritePayload(payloadPath)
+    return await processPayload(payloadPath)
   })
 
-  async function process(page) {
+  /**
+   * Converts regex matches for both HTML and PAYLOAD responses into an Array of URL Objects
+   */
+  function urlsFromMatches (matches, isPayloadFormat = false) {
     const urls = []
-    const test = new RegExp('(http(s?):)([/|.|\\w|\\s|-]|%|:|~)*.(?:' + options.extensions.join('|') + '){1}[^"]*', 'g')
-    const matches = page.html.matchAll(test)
     for (const match of matches) {
-			const baseUrl = new URL(moduleOptions.baseUrl)
-			const responsiveImagesRegex = /,?\s{1}[\d.]+[xwh]\s?,?\s?/gm;
-			const responsiveImageMatches = match[0].match(responsiveImagesRegex)
-			let matchURLStrings = [match[0]]
-			if ( responsiveImageMatches && responsiveImageMatches.length ) {
-				matchURLStrings = match[0].split(responsiveImagesRegex).filter(item => item.length)
-			}
-			const matchURLs = matchURLStrings.map(matchStr => new URL(matchStr));
-
-			matchURLs.forEach(url => {
-				if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
-					urls.push(url)
-				}
-			})
-		}
-    if (!urls.length) return
-    consola.info(`${page.route}: nuxt-image-extractor is replacing ${urls.length} images with local copies`)
-    return await replaceRemoteImages(page.html, urls).then((html) => (page.html = html))
+      let matchURLStrings = isPayloadFormat ? [decodeURIComponent(JSON.parse('"' + removeTrailingBackslash(match[0]) + '"'))] : [match[0]]
+      const responsiveImagesRegex = /,?\s{1}[\d.]+[xwh]\s?,?\s?/gm
+      const responsiveImageMatches = match[0].match(responsiveImagesRegex)
+      if (responsiveImageMatches && responsiveImageMatches.length) {
+        matchURLStrings = match[0].split(responsiveImagesRegex).filter(item => item.length)
+      }
+      const matchUrls = matchURLStrings.map(matchStr => new URL(matchStr))
+      matchUrls.forEach((url) => {
+        if (baseUrl.hostname === url.hostname && !urls.find(u => u.href === url.href)) {
+          urls.push(url)
+        }
+      })
+    }
+    return urls
   }
 
-  async function replaceRemoteImages(html, urls) {
+  /**
+   * Parses the generated page HTML for Asset URLs and replaces them in the page HTML
+   */
+  async function processPage (page) {
+    const test = new RegExp('(http(s?):)([/|.|\\w|\\s|-]|%|:|~)*.(?:' + options.extensions.join('|') + '){1}[^"]*', 'g')
+    const matches = page.html.matchAll(test)
+    const urls = urlsFromMatches(matches)
+    if (!urls.length) { return }
+    consola.info(`${page.route}: nuxt-image-extractor is replacing ${urls.length} images with local copies`)
+    return await replaceRemoteImages(page.html, urls).then(html => (page.html = html))
+  }
+
+  async function replaceRemoteImages (html, urls) {
     await Promise.all(
       urls.map(async (url) => {
         const ext = '.' + (url.pathname + url.hash).split('.').pop()
@@ -64,47 +74,39 @@ module.exports = function Extract(moduleOptions) {
           .then(() => {
             html = html.split(url.href).join(options.path + '/' + name)
           })
-          .catch((e) => consola.error(e))
+          .catch(e => consola.error(e))
       })
     )
     return html
   }
 
-  function encodeSlashes(str) {
+  function encodeSlashes (str) {
     return str.replace(/\//g, '\\u002F')
   }
 
-  function rewritePayload(payloadPath) {
+  /**
+   * Process the AJAX Payload objects, parse the URLs, download the objects
+   */
+  async function processPayload (payloadPath) {
     // Parse payload.js to get encoded URIs
     const test = new RegExp(
       '(http(s?):)([\\\\u002F|.|\\w|\\s|-]|%|:|~|\\\\u002F)*.(?:' + options.extensions.join('|') + '){1}[^"]*',
       'g'
     )
 
-    const urls = []
+    const data = await fs.readFileSync(payloadPath, 'utf8')
+    const matches = data.matchAll(test)
 
-    fs.readFile(payloadPath, 'utf8', async (err, data) => {
-      if (err) return consola.error(err)
-      const matches = data.matchAll(test)
+    // We might expect match[0] to be like:
+    // https:\u002F\u002Fsubdomain.domain.com\u002Fassets\u002Fsome-image-5038843-1.jpg
+    const urls = urlsFromMatches(matches, true)
+    if (!urls.length) { return }
 
-      for (const match of matches) {
-        const baseUrl = new URL(moduleOptions.baseUrl)
-        const url = new URL(decodeURIComponent(JSON.parse('"' + removeTrailingBackslash(match[0]) + '"')))
-        if (baseUrl.hostname === url.hostname && !urls.find((u) => u.href === url.href)) {
-          urls.push(url)
-        }
-      }
-      if (!urls.length) return
-
-      await replacePayloadImageLinks(data, urls).then((payload) => {
-        fs.writeFile(payloadPath, payload, 'utf8', (err) => {
-          if (err) return consola.error(err)
-        })
-      })
-    })
+    const payload = await downloadAndReplacePayloadImageLinks(data, urls)
+    await fs.writeFileSync(payloadPath, payload, 'utf8')
   }
 
-  function encodeChars(str) {
+  function encodeChars (str) {
     return (
       str
         .replace(/%/g, '%25') // Needs to be first in the chain
@@ -129,10 +131,13 @@ module.exports = function Extract(moduleOptions) {
     )
   }
 
-  async function replacePayloadImageLinks(payload, urls) {
+  /**
+   * Download the images and update the payload content
+   */
+  async function downloadAndReplacePayloadImageLinks (payload, urls) {
     let count = 0
     await Promise.all(
-      urls.map((url) => {
+      urls.map(async (url) => {
         const ext = '.' + (url.pathname + url.hash).split('.').pop()
         const preName = (url.pathname + url.hash).split(ext).join('')
         const name = slugify(encodeChars(preName)) + ext.split('?')[0]
@@ -140,6 +145,9 @@ module.exports = function Extract(moduleOptions) {
         let remoteLink = url.href.split('.')
         remoteLink.pop()
         remoteLink = encodeSlashes(encodeChars(remoteLink.join('.'))) + ext
+
+        const imgPath = join(baseDir, name)
+        await saveRemoteImage(url, imgPath)
 
         payload = payload.split(remoteLink).join(encodeSlashes(encodeChars(routerBase + options.path + '/')) + name)
         count++
@@ -150,10 +158,14 @@ module.exports = function Extract(moduleOptions) {
   }
 }
 
-async function saveRemoteImage(url, path) {
+/**
+ * Save an asset to the filesystem
+ */
+async function saveRemoteImage (url, path) {
   const res = await fetch(url)
-  if(!res.ok) {
-    consola.error(`Failed to fetch: ${url} - Status: ${res.status}`)
+  consola.info(`nuxt-image-extractor fetching ${url}`)
+  if (!res.ok) {
+    consola.error(`nuxt-image-extractor failed to fetch: ${url} - Status: ${res.status}`)
     process.exit(1)
   }
   const fileStream = fs.createWriteStream(path)
@@ -169,7 +181,7 @@ async function saveRemoteImage(url, path) {
 }
 
 // https://gist.github.com/codeguy/6684588
-function slugify(text) {
+function slugify (text) {
   return text
     .toString()
     .toLowerCase()
@@ -181,7 +193,7 @@ function slugify(text) {
     .replace(/--+/g, '-')
 }
 
-function removeTrailingBackslash(str) {
+function removeTrailingBackslash (str) {
   return str.replace(/\\+$/, '')
 }
 


### PR DESCRIPTION
Hi again!

This is a slightly larger change that developed from assets not being downloaded when mentioned as part of payloads.

- Reparsed based on the default eslint settings
- Added image fetching from the Payload files. It was clear the URLs were being replaced, but it seems the assets hadn't been downloaded.
- Pulled out `urlsFromMatches` as it (and the srcset logic) needs to be used in two places (PAGE and PAYLOAD)
- Renamed some functions based to reflect usage more accurately 

Let me know if anything needs to change!